### PR TITLE
RT651765 - add recipe for google client java api

### DIFF
--- a/recipes/google-api-java-client/build.sh
+++ b/recipes/google-api-java-client/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+INSTALL_FOLDER=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
+
+mkdir -p $INSTALL_FOLDER
+cp -r java/lib $INSTALL_FOLDER/
+ls -lt $INSTALL_FOLDER

--- a/recipes/google-api-java-client/meta.yaml
+++ b/recipes/google-api-java-client/meta.yaml
@@ -1,0 +1,28 @@
+{% set name = "google-api-java-client" %}
+{% set version = "1.47.1" %}
+{% set hash = "ddd1119a591230f0f7358321c6f8be38964e332433c4b68549ff0566a5800e58" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: http://storage.googleapis.com/gdata-java-client-binaries/gdata-src.java-{{ version }}.zip
+  sha256: {{ hash }}
+
+build:
+  number: 0
+
+requirements:
+  host:
+    - openjdk >=8
+  run:
+    - openjdk >=8
+
+about:
+  home: https://github.com/googleapis/google-api-java-client
+  license: Apache-2.0
+  license_family: Apache
+  summary: "Google APIs Client Library for Java"
+


### PR DESCRIPTION
Add recipe for google-client-java-api
Available on sanger-pathogens conda channel:
https://anaconda.org/sanger-pathogens/google-api-java-client

To build:
conda build <package_name>

To convert:
conda convert <package_name> -p all

To upload:
anaconda login
anaconda upload <arch>/<package_filename>