### PR TITLE
Rt651765 javax activation

### DIFF
--- a/environments/production/sanger-pathogens-deployment.yml
+++ b/environments/production/sanger-pathogens-deployment.yml
@@ -52,7 +52,6 @@ dependencies:
   - perl-parent=0.236
   - perl-storable=3.11
   - perl-sub-uplevel=0.2800
-  - perl-test-deep=1.128
   - perl-test-differences=0.64
   - perl-test-exception=0.43
   - perl-test-most=0.35
@@ -73,6 +72,9 @@ dependencies:
   - perl=5.26.2
   - zlib=1.2.11
   - perl-inline=0.80
+  - perl-test-deep=1.128
+  - perl-test-nowarnings=1.04
   - perl-yaml-xs=0.74
   - google-api-java-client=1.47.1
+  - javabeans-activation-framework=1.1.1
 

--- a/recipes/javabeans-activation-framework/build.sh
+++ b/recipes/javabeans-activation-framework/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Download
+curl -v -O -L -b oraclelicense=accept-securebackup-cookie -o jaf-1_1_1.zip http://download.oracle.com/otn-pub/java/jaf/1.1.1/jaf-1_1_1.zip
+
+# Extract files
+unzip jaf-1_1_1.zip
+mv jaf-1.1.1 "$PREFIX/jaf-1.1.1"
+
+INSTALL_FOLDER=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
+
+mkdir -p $INSTALL_FOLDER
+cp $PREFIX/jaf-1.1.1/activation.jar $INSTALL_FOLDER/
+ls -lt $INSTALL_FOLDER

--- a/recipes/javabeans-activation-framework/meta.yaml
+++ b/recipes/javabeans-activation-framework/meta.yaml
@@ -1,0 +1,22 @@
+{% set name = "javabeans-activation-framework" %}
+{% set version = "1.1.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+build:
+  number: 0
+
+requirements:
+  host:
+    - openjdk >=8
+  build:
+    - curl
+  run:
+    - openjdk >=8
+
+about:
+  home: http://download.oracle.com
+  license: Oracle Binary Code License Agreement for Java SE and JavaFX Technologies 
+  summary: "JavaBeans Activation Framework"

--- a/recipes/javabeans-activation-framework/pre-link.sh
+++ b/recipes/javabeans-activation-framework/pre-link.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "By installing the JDK package, you are agreeing to the Oracle Binary Code License Agreement for Java SE."


### PR DESCRIPTION
With java 11 it looks like the activation framework is a missing dependency for the general repository
These commits add the recipe and update the sanger-pathogens-deployment environment to include the package.